### PR TITLE
Define last exynos5410 smc call

### DIFF
--- a/trustzone/tzsw.S
+++ b/trustzone/tzsw.S
@@ -568,7 +568,7 @@ handle_smc:
 	cmn	r0, #7
 	beq	smc_cmd_standby
 	cmn	r0, #26
-	beq	smc_cmd_unknown
+	beq	smc_cmd_swreset
 	cmn	r0, #128
 	beq	smc_cmd_enable_debug
 	cmn	r0, #256
@@ -956,8 +956,7 @@ go_idle:
 
 
 /* Offset: 0x007FC */
-/* Which command is this? */
-smc_cmd_unknown:
+smc_cmd_swreset:
 	ldr	r0, =(EXYNOS5_CLKGATE_BUS_CDREX)
 	ldr	r1, [r0]
 	bic	r1, r1, #0xC0			@ again the same clocks

--- a/trustzone/tzsw.h
+++ b/trustzone/tzsw.h
@@ -35,6 +35,7 @@
 #define SMC_CMD_L2X0SETUP2	(-23)
 #define SMC_CMD_L2X0INVALL	(-24)
 #define SMC_CMD_L2X0DEBUG	(-25)
+#define SMC_CMD_SWRESET		(-26)
 
 /* For Accessing CP15/SFR (General) */
 #define SMC_CMD_REG		(-101)


### PR DESCRIPTION
Hi,

I realise that this repo isn't exactly actively developed, but it is possibly the best/only good resource for understanding the trustzone firmware on exynos5, so here is a PR for describing the last unknown call.

-26 is SWRESET, seen in Samsung's kernel for [exynos5420's](https://github.com/exynos5420/android_kernel_samsung_exynos5420/blob/lineage-17.1/arch/arm/mach-exynos/include/mach/smc.h#L32).
